### PR TITLE
switch outdated ImageMagick dependency to gm module

### DIFF
--- a/lib/ImageMagick.js
+++ b/lib/ImageMagick.js
@@ -4,7 +4,7 @@ var fs = require('fs'),
   crypto = require('crypto'),
   mkdirp = require('mkdirp'),
   async = require('async'),
-  im = require('imagemagick'),
+  gm = require('gm'),
   mmm = require('mmmagic'),
   Magic = mmm.Magic,
   check = require('check-types'),
@@ -58,9 +58,11 @@ ImageMagick.prototype.createFieldSchema = function() {
 }
 
 ImageMagick.prototype.process = function(attachment, storageProvider, model, callback) {
-  im.identify(attachment.path, function(error, attributes) {
-    if(!attributes || this._options.formats.indexOf(attributes.format) == -1) {
-      return callback(new Error('File was not an image'))
+  gm(attachment.path)
+    .options({imageMagick: this._options})
+    .identify(function(error, attributes) {
+      if(!attributes || this._options.formats.indexOf(attributes.format) == -1) {
+        return callback(new Error('File was not an image'))
     }
 
     var tasks = []
@@ -116,12 +118,12 @@ ImageMagick.prototype._setUpTransform = function(attachment, transform, outputFi
 
   tasks.push(function(callback) {
     async.waterfall([function(callback) {
-      var args = [attachment.path].concat(self._setUpConvertArgs(transform))
-      args.push(outputFile)
-
-      im.convert(args, callback)
-    }, function(stdout, stderr, callback) {
-      im.identify(outputFile, callback)
+      var args = self._setUpConvertArgs(transform)
+      var processor = gm(attachment.path).options({imageMagick: this._options}).command('convert')
+      processor.out.apply(processor, args).write(outputFile, callback)
+    }, function(error) {
+      var callback = arguments[arguments.length - 1]
+      gm(outputFile).options({imageMagick: this._options}).identify(callback)
     }, function(attributes, callback) {
       fs.stat(outputFile, function(error, stats) {
         callback(error, outputFile, attributes, stats)
@@ -141,8 +143,8 @@ ImageMagick.prototype._setUpTransform = function(attachment, transform, outputFi
     }], function(error, outputFile, attributes, stats, mimeType, url) {
       model.format = attributes.format
       model.depth = attributes.depth
-      model.width = attributes.width
-      model.height = attributes.height
+      model.width = attributes.size.width
+      model.height = attributes.size.height
       model.size = stats.size
       model.url = url
       model.name = attachment.name

--- a/lib/ImageMagick.js
+++ b/lib/ImageMagick.js
@@ -59,7 +59,7 @@ ImageMagick.prototype.createFieldSchema = function() {
 
 ImageMagick.prototype.process = function(attachment, storageProvider, model, callback) {
   gm(attachment.path)
-    .options({imageMagick: this._options})
+    .options({imageMagick: !this._options.gm})
     .identify(function(error, attributes) {
       if(!attributes || this._options.formats.indexOf(attributes.format) == -1) {
         return callback(new Error('File was not an image'))
@@ -119,11 +119,11 @@ ImageMagick.prototype._setUpTransform = function(attachment, transform, outputFi
   tasks.push(function(callback) {
     async.waterfall([function(callback) {
       var args = self._setUpConvertArgs(transform)
-      var processor = gm(attachment.path).options({imageMagick: this._options}).command('convert')
+      var processor = gm(attachment.path).options({imageMagick: !self._options.gm}).command('convert')
       processor.out.apply(processor, args).write(outputFile, callback)
     }, function(error) {
       var callback = arguments[arguments.length - 1]
-      gm(outputFile).options({imageMagick: this._options}).identify(callback)
+      gm(outputFile).options({imageMagick: !self._options.gm}).identify(callback)
     }, function(attributes, callback) {
       fs.stat(outputFile, function(error, stats) {
         callback(error, outputFile, attributes, stats)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "mongoose-crate": "^1.0.0",
     "async": "^0.9",
-    "imagemagick": "^0.1",
+    "gm": "^1.17.0",
     "mkdirp": "^0.5",
     "mmmagic": "^0.3",
     "check-types": "^1.2"


### PR DESCRIPTION
Maybe It's better just to create another processor, since it uses GraphicsMagick binaries instead of ImageMagick? #3 
